### PR TITLE
Update for rollups v0.7.0

### DIFF
--- a/docker-compose-testnet.yml
+++ b/docker-compose-testnet.yml
@@ -10,7 +10,7 @@ x-credentials: &postgres-config
 
 services:
   rollups_dispatcher:
-    image: cartesi/rollups-dispatcher:0.6.1
+    image: cartesi/rollups-dispatcher:0.7.0
     command:
       [
         "--rd-dapp-contract-address-file",
@@ -48,7 +48,7 @@ services:
       - ./deployments:/deployments
 
   state_server:
-    image: cartesi/rollups-state-server:0.6.1
+    image: cartesi/rollups-state-server:0.7.0
     command:
       [
         "--sf-genesis-block",
@@ -83,7 +83,7 @@ services:
       - machine:/opt/cartesi/share/dapp-bin
 
   rollups_inspect_server:
-    image: cartesi/rollups-inspect-server:0.6.1
+    image: cartesi/rollups-inspect-server:0.7.0
     command:
       [
         "--inspect-server-address",
@@ -103,7 +103,7 @@ services:
       RUST_LOG: info
 
   rollups_indexer:
-    image: cartesi/rollups-indexer:0.6.1
+    image: cartesi/rollups-indexer:0.7.0
     command:
       [
         "--dapp-contract-address-file",
@@ -138,7 +138,7 @@ services:
       - ./deployments:/deployments
 
   query_server:
-    image: cartesi/query-server:0.6.1
+    image: cartesi/query-server:0.7.0
     ports:
       - "4000:4000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-credentials: &postgres-config
 
 services:
   hardhat:
-    image: cartesi/rollups-hardhat:0.6.1
+    image: cartesi/rollups-hardhat:0.7.0
     command:
       [
         "node",
@@ -33,7 +33,7 @@ services:
       - ./export:/opt/cartesi/share/blockchain
 
   rollups_dispatcher:
-    image: cartesi/rollups-dispatcher:0.6.1
+    image: cartesi/rollups-dispatcher:0.7.0
     command:
       [
         "--rd-dapp-contract-address-file",
@@ -74,7 +74,7 @@ services:
       - ./export:/opt/cartesi/share/blockchain:ro
 
   state_server:
-    image: cartesi/rollups-state-server:0.6.1
+    image: cartesi/rollups-state-server:0.7.0
     command:
       [
         "--sf-genesis-block",
@@ -176,7 +176,7 @@ services:
       ]
 
   rollups_inspect_server:
-    image: cartesi/rollups-inspect-server:0.6.1
+    image: cartesi/rollups-inspect-server:0.7.0
     command:
       [
         "--inspect-server-address",
@@ -196,7 +196,7 @@ services:
       RUST_LOG: warn
 
   rollups_indexer:
-    image: cartesi/rollups-indexer:0.6.1
+    image: cartesi/rollups-indexer:0.7.0
     command:
       [
         "--dapp-contract-address-file",
@@ -234,7 +234,7 @@ services:
       - ./export:/opt/cartesi/share/blockchain
 
   query_server:
-    image: cartesi/query-server:0.6.1
+    image: cartesi/query-server:0.7.0
     ports:
       - "4000:4000"
     depends_on:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # layers for caching and versioning
 FROM cartesi/toolchain:0.11.0 as toolchain
 FROM cartesi/rootfs:0.14.1 as rootfs
-FROM cartesi/server-manager:0.4.1 as server-manager
+FROM cartesi/server-manager:0.4.2 as server-manager
 
 FROM rootfs as toolchain-python
 


### PR DESCRIPTION
## Description

As title says, this PR updates the docker images to the new versions released with 0.7.0.

I've also updated the `juztamau5/rollups-cli:devel` docker image that includes https://github.com/cartesi/rollups/pull/2 and https://github.com/cartesi/rollups/pull/3.

## How has this been tested?

Builds successfully. I haven't runtime tested yet.
