### PR TITLE
Deploy Ultrachess contracts

### DIFF
--- a/docker-compose-testnet.yml
+++ b/docker-compose-testnet.yml
@@ -10,7 +10,7 @@ x-credentials: &postgres-config
 
 services:
   rollups_dispatcher:
-    image: cartesi/rollups-dispatcher:0.7.0
+    image: juztamau5/rollups-dispatcher:devel
     command:
       [
         "--rd-dapp-contract-address-file",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-credentials: &postgres-config
 
 services:
   hardhat:
-    image: cartesi/rollups-hardhat:0.7.0
+    image: juztamau5/rollups-hardhat:devel
     command:
       [
         "node",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,24 @@ services:
       - ./deployments:/app/deployments
       - ./export:/opt/cartesi/share/blockchain
 
+  ultrachess_deployer:
+    image: juztamau5/ultrachess-deployer:devel
+    restart: on-failure
+    depends_on:
+      hardhat:
+        condition: service_healthy
+    command:
+      [
+        "deploy",
+        "--network",
+        "docker",
+        "--export",
+        "/opt/cartesi/share/blockchain/localhost-ultrachess.json",
+      ]
+    volumes:
+      - ./deployments:/app/deployments
+      - ./export:/opt/cartesi/share/blockchain
+
   rollups_dispatcher:
     image: cartesi/rollups-dispatcher:0.7.0
     command:
@@ -152,6 +170,8 @@ services:
       hardhat:
         condition: service_healthy
       deployer:
+        condition: service_completed_successfully
+      ultrachess_deployer:
         condition: service_completed_successfully
     command:
       [

--- a/export/.gitignore
+++ b/export/.gitignore
@@ -1,1 +1,2 @@
 localhost.json
+localhost-ultrachess.json

--- a/front/src/ether/contracts.js
+++ b/front/src/ether/contracts.js
@@ -16,6 +16,8 @@ import * as CartesiTokenPolygonMainnet from "@cartesi/token/deployments/polygon_
 import * as CartesiTokenPolygonMumbai from "@cartesi/token/deployments/polygon_mumbai/CartesiToken.json";
 import * as SimpleFaucetGoerli from "@cartesi/token/deployments/goerli/SimpleFaucet.json";
 import { contracts as contractsLocalhost } from "../abis/localhost.json";
+import { contracts as ultrachessLocalhost } from "../../../export/localhost-ultrachess.json";
+
 
 export const CONTRACTS = {
   arbitrum_goerli: {
@@ -32,7 +34,7 @@ export const CONTRACTS = {
       InputFacet: InputFacetGoerli,
       SimpleFaucet: SimpleFaucetGoerli,
   },
-  localhost: contractsLocalhost,
+  localhost: Object.assign({}, contractsLocalhost, ultrachessLocalhost),
   mainnet: {
       CartesiToken: CartesiTokenMainnet,
   },


### PR DESCRIPTION
## Description

This PR deploys the contracts in our [contracts repo](https://github.com/Ultrachess/contracts) to the Docker composition for use in the browser.

The PR also switches the rollups repo for our org one. I've published to my username instead of a Docker org because Docker orgs start at $300/mo.

Compared to the 0.7.0 release, our rollups branch includes:

* https://github.com/cartesi/rollups/pull/2
* https://github.com/cartesi/rollups/pull/3
* https://github.com/cartesi/rollups/pull/4

## Motivation and context

Needed for chess AI NFTs.

## How has this been tested?

I hooked up the DeFi contracts and minted an LP SFT in the UI:

![CHESS-ultra3CRV LP SFT](https://user-images.githubusercontent.com/15795328/217420293-bfca5517-c7bd-42bc-aa60-04ccb0bad0d8.png)
