### PR TITLE
Add Kubo IPFS dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,42 @@
 # syntax=docker.io/docker/dockerfile:1.4
+FROM cartesi/toolchain:0.12.0 as go-build
+
+# Install Go build dependencies
+RUN <<EOF
+apt-get update
+DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+  gccgo \
+  git \
+  golang-go \
+  make \
+  wget
+rm -rf /var/lib/apt/lists/*
+EOF
+
+# Download Kubo source
+ENV KUBO_VERSION=0.18.1
+WORKDIR /tmp/build
+RUN <<EOF
+wget https://github.com/ipfs/kubo/archive/refs/tags/v${KUBO_VERSION}.tar.gz
+tar xzf v${KUBO_VERSION}.tar.gz
+mv kubo-${KUBO_VERSION} kubo
+EOF
+
+# Build Kubo
+# tcp package was patched for RISC-V support
+ENV TCP_VERSION=f510bf496e14dabbd6a04b61defcf98210ce08a7
+WORKDIR /tmp/build/kubo
+RUN <<EOF
+export GOOS=linux
+export GOARCH=riscv64
+export CC_FOR_TARGET=riscv64-cartesi-linux-gnu-gcc
+export CXX_FOR_TARGET=riscv64-cartesi-linux-gnu-g++
+export GOPATH=/tmp/build/go
+go mod edit -replace github.com/marten-seemann/tcp=github.com/juztamau5/tcp@${TCP_VERSION}
+go mod tidy
+make install
+EOF
+
 FROM toolchain-python
 
 # Enter directory for building dapp
@@ -26,6 +64,9 @@ cd server
 . .venv/bin/activate
 pip install -r requirements.txt
 EOF
+
+# Import Go binaries
+COPY --from=go-build /tmp/build/go/bin/linux_riscv64 bin
 
 # Copy files
 COPY dapp.json .

--- a/dapp.json
+++ b/dapp.json
@@ -1,6 +1,6 @@
 {
   "fs": {
-    "files": ["server", "entrypoint.sh"],
-    "size": 128000
+    "files": ["bin", "entrypoint.sh", "server"],
+    "size": 256000
   }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright 2022 Cartesi Pte. Ltd.
+# Copyright 2023 Ultrachess team
 #
 # SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -11,5 +12,33 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-set -e
-PYTHONPATH=/mnt/dapp/server/.venv/cross/lib/python3.10/site-packages rollup-init python3 server/main.py
+# Enable strict shell mode
+set -o errexit
+set -o nounset
+set -o pipefail
+
+################################################################################
+# Environement configuration
+################################################################################
+
+# The current Python version
+PYTHON_VERSION="3.10"
+
+################################################################################
+# Environement paths
+################################################################################
+
+# Get the absolute path to the entrypoint script
+SCRIPT_DIR="$(pwd)"
+
+# Add the "bin" subdirectory to PATH
+export PATH="${SCRIPT_DIR}/bin:${PATH}"
+
+# Add the Python cross environment to PYTHONPATH
+export PYTHONPATH="${SCRIPT_DIR}/server/.venv/cross/lib/python${PYTHON_VERSION}/site-packages"
+
+################################################################################
+# Entry point
+################################################################################
+
+rollup-init python3 server/main.py

--- a/server/main.py
+++ b/server/main.py
@@ -20,6 +20,7 @@ import string
 import traceback
 from eth_abi import decode_abi
 from times import set_timestamp
+import subprocess
 
 logging.basicConfig(level="INFO")
 logger = logging.getLogger(__name__)
@@ -32,6 +33,9 @@ rollup_address = "0xF119CC4Ed90379e5E0CC2e5Dd1c8F8750BAfC812"
 logger.info(f"HTTP rollup_server url is {rollup_server}")
 
 lastProcessedBlock = 0
+
+# Initialize IPFS
+subprocess.run(['ipfs', 'init'])
 
 def format_to_input(index, sender, operation, value, success, timeStamp):
     data_set = {


### PR DESCRIPTION
## Description

This PR adds IPFS as a dependency. It calls `ipfs init` in the `main()` startup so that ipfs calls are available in the application loop.

As a result, in addition to IPFS, all Go dependencies (including Ikemen) can be used in the dapp.

The intended usage is to call `ipfs add` on bot binaries to provide an IPFS link for the NFT URI metadata.

## How has this been tested?

When I try to create a game, it calls:

```json
{
    "op": "create", 
    "value": {
        "name" : "default",
        "isBot" : false,
        "botId1" : "blank",
        "botId2" : "blank",
        "playerId" : "blank",
        "token" : "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
        "wagerAmount" : 0,
        "bettingDuration" : 60
    }
}
```

After, a game is created:

![Screenshot from 2023-02-15 03-33-54](https://user-images.githubusercontent.com/15795328/219016573-3c789446-9d94-4b30-8f18-3e05d827ecd3.png)

The output of creating a VM is:

```
#89 [server machine-server 5/6] RUN build-machine.sh /opt/cartesi/share/dapp-bin
#89 1.569 
#89 1.569          .
#89 1.569         / \
#89 1.569       /    \
#89 1.569 \---/---\  /----\
#89 1.569  \       X       \
#89 1.570   \----/  \---/---\
#89 1.570        \    / CARTESI
#89 1.570         \ /   MACHINE
#89 1.570          '
#89 1.570 
#89 2.100 [INFO  rollup_http_server] starting http dispatcher service...
#89 2.101 [INFO  rollup_http_server::http_service] starting http dispatcher http service!
#89 2.116 [INFO  actix_server::builder] Starting 1 workers
#89 2.117 [INFO  actix_server::server] Actix runtime found; starting in Actix runtime
#89 2.152 [INFO  rollup_http_server::dapp_process] starting dapp: python3 server/main.py
#89 66.49 INFO:__main__:HTTP rollup_server url is http://127.0.0.1:5004
#89 69.56 generating ED25519 keypair...done
#89 70.30 peer identity: 12D3KooWQDjCSJzBnNmNjEPV7Cwu6zU8J3YENoG3eWtDEtYXBKUk
#89 70.31 initializing IPFS node at /home/dapp/.ipfs
#89 72.42 to get started, enter:
#89 72.42 
#89 72.42 	ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme
#89 72.42 
#89 72.45 1970-01-01T00:00:49.849Z	ERROR	provider.queue	queue/queue.go:125	Failed to enqueue cid: leveldb: closed
#89 73.67 
#89 73.67 Manual yield rx-accepted (0x100000000 data)
#89 73.67 Cycles: 5083709141
#89 73.67 Storing machine: please wait
#89 DONE 82.0s
```

Showing that `ipfs init` ran successfully.