### PR TITLE
Enable missing DeFi smart contracts

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -89,7 +89,7 @@ jobs:
       # Deploy dapp and smart contracts
       - name: Deploy dapp
         if: steps.restore-artifacts.outputs.cache-hit != 'true'
-        run: docker compose -f docker-compose-deploy.yml -f docker-compose.override.yml up --exit-code-from ultrachess_deployer || true
+        run: docker compose -f docker-compose-deploy.yml -f docker-compose.override.yml run finished
 
       - name: yarn run build
         working-directory: front

--- a/deployments/localhost/dapp.json
+++ b/deployments/localhost/dapp.json
@@ -1,6 +1,0 @@
-{
-    "address": "0x2ed38C41dfB4De75a56027fE8121b143DC04b0eC",
-    "blockHash": "0xa8c178831ba313b0ce65d8093978adbae065332d92904a335e788ff7c2bcd93c",
-    "blockNumber": 31,
-    "transactionHash": "0xe3f7ddd38e16c1fa7c63d85a59754467f9ccfc139c1d80ddc8bd7256e967b99f"
-}

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -17,9 +17,9 @@ services:
     healthcheck:
       test:
         ["CMD", "test", "-f", "/opt/cartesi/share/blockchain/localhost.json"]
-      interval: 30s
+      interval: 10s
       timeout: 30s
-      retries: 5
+      retries: 15
     volumes:
       - ./deployments:/app/rollups/deployments
       - ./export:/opt/cartesi/share/blockchain
@@ -72,8 +72,6 @@ services:
     depends_on:
       hardhat:
         condition: service_healthy
-      deployer:
-        condition: service_completed_successfully
     command:
       [
         "deploy",
@@ -85,6 +83,14 @@ services:
     volumes:
       - ./deployments:/app/rollups/deployments
       - ./export:/opt/cartesi/share/blockchain
+
+  finished:
+    image: hello-world:latest # Close to scratch image
+    depends_on:
+        deployer:
+            condition: service_completed_successfully
+        ultrachess_deployer:
+            condition: service_completed_successfully
 
 volumes:
   machine: {}

--- a/front/src/ether/contracts.js
+++ b/front/src/ether/contracts.js
@@ -16,8 +16,8 @@ import * as CartesiTokenOptimismMainnet from "@cartesi/token/deployments/optimis
 import * as CartesiTokenPolygonMainnet from "@cartesi/token/deployments/polygon_mainnet/CartesiToken.json";
 import * as CartesiTokenPolygonMumbai from "@cartesi/token/deployments/polygon_mumbai/CartesiToken.json";
 
+import { contracts as ultrachessLocalhost } from "../../../export/localhost-ultrachess.json";
 import { contracts as contractsLocalhost } from "../abis/localhost.json";
-//import { contracts as ultrachessLocalhost } from "../../../export/localhost-ultrachess.json";
 
 export const CONTRACTS = {
   arbitrum_goerli: {
@@ -34,7 +34,7 @@ export const CONTRACTS = {
     InputFacet: InputFacetGoerli,
     SimpleFaucet: SimpleFaucetGoerli,
   },
-  localhost: Object.assign({}, contractsLocalhost),
+  localhost: Object.assign({}, contractsLocalhost, ultrachessLocalhost),
   mainnet: {
     CartesiToken: CartesiTokenMainnet,
   },


### PR DESCRIPTION
## Description

This PR tweaks the CI yml files to make sure that the appropriate file (`localhost-ultrachess.json`) is generated.

Previously, the docker composition was always terminated early. I couldn't figure out a way for it to `wait` until both `localhost.json` and `localhost-ultrachess.json` were generated, until I realized that you need to be really explicit for docker commands to successfully block.

I added a `finished` target that blocks until both deployers are finished, and this successfully blocks until both `localhost.json` and `localhost-ultrachess.json` are generated.

## Motivation and context

Even though this currently only deploys DeFi contracts, it'll be needed for upcoming AI NFTs that interface with DeFi.

## How has this been tested?

Before:

```
  Could not resolve "../../../export/localhost-ultrachess.json" from "src/ether/contracts.js"
```

After:

CI succeeds, which includes DeFi (and soon to be AI NFT) contracts.