### PR TITLE
Add copyright headers and remove unused imports

### DIFF
--- a/front/codegen.yml
+++ b/front/codegen.yml
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 schema: ./src/graphql/schema.graphql
 documents: ./src/graphql/queries.graphql
 generates:

--- a/front/src/App.css
+++ b/front/src/App.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 .App {
   text-align: center;
 }

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,9 +1,17 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import "./App.css";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 import Body from "./components/Body";
 import BotManager from "./components/BotManager";
@@ -15,11 +23,8 @@ import PageKingOfTheHill from "./components/PageKingOfTheHill";
 import Profile from "./components/Profile";
 import Rankings from "./components/Rankings";
 import Tournaments from "./components/Tournaments";
-import Tournament from "./components/TournamentView";
 import TournamentView from "./components/TournamentView";
 import TransitionManager from "./components/TransitionManager";
-import logo from "./logo.svg";
-import { fetchGames } from "./state/game/gameSlice";
 import { GameStateUpdater } from "./state/game/updater";
 import { TransactionUpdater } from "./state/transactions/updater";
 

--- a/front/src/common/types.ts
+++ b/front/src/common/types.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 export enum TransactionType {
   SEND_MOVE_INPUT,
   CREATE_GAME_INPUT,

--- a/front/src/components/ActionItem.tsx
+++ b/front/src/components/ActionItem.tsx
@@ -1,17 +1,21 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { useEffect, useState } from "react";
-import Col from "react-bootstrap/Col";
 import ProgressBar from "react-bootstrap/ProgressBar";
-import Row from "react-bootstrap/Row";
-import Toast from "react-bootstrap/Toast";
 
 import { TransactionType } from "../common/types";
 import { useAction } from "../state/game/hooks";
-import { Action, ActionStates } from "../state/game/types";
+import { ActionStates } from "../state/game/types";
 import { useTransaction } from "../state/transactions/hooks";
 import Address from "./Address";
 import AddressGame from "./AddressGame";
 import AssetDisplay from "./AssetDisplay";
-import DateDisplay from "./ui/Date";
 import { Text } from "./ui/Text";
 
 const statusToString = {

--- a/front/src/components/ActionView.tsx
+++ b/front/src/components/ActionView.tsx
@@ -1,11 +1,16 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { useEffect, useState } from "react";
-import Col from "react-bootstrap/Col";
 import ProgressBar from "react-bootstrap/ProgressBar";
-import Row from "react-bootstrap/Row";
 import Toast from "react-bootstrap/Toast";
 
 import { TransactionType } from "../common/types";
-import { useAction } from "../state/game/hooks";
 import { Action, ActionStates } from "../state/game/types";
 import { useTransaction } from "../state/transactions/hooks";
 import Address from "./Address";

--- a/front/src/components/Address.css
+++ b/front/src/components/Address.css
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */

--- a/front/src/components/Address.jsx
+++ b/front/src/components/Address.jsx
@@ -1,8 +1,13 @@
-import React, { useMemo, useRef } from "react";
-import { Grid, User } from "@nextui-org/react";
-import { createIcon } from "@download/blockies";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { Row } from "react-bootstrap";
 import ProfileImage from "./ProfileImage";
 import { truncateAddress } from "../ether/utils";
 import { Text } from "./ui/Text";

--- a/front/src/components/AddressGame.tsx
+++ b/front/src/components/AddressGame.tsx
@@ -1,10 +1,15 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import "./Address.css";
 
-import { Row } from "react-bootstrap";
 import { Link } from "react-router-dom";
 
-import { truncateAddress } from "../ether/utils";
-import ProfileImage from "./ProfileImage";
 import { Text } from "./ui/Text";
 
 export default ({ id }: { id: string }) => {

--- a/front/src/components/AddressTournament.tsx
+++ b/front/src/components/AddressTournament.tsx
@@ -1,10 +1,16 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import "./Address.css";
 
 import { Row } from "react-bootstrap";
 import { Link } from "react-router-dom";
 
-import { truncateAddress } from "../ether/utils";
-import ProfileImage from "./ProfileImage";
 import { Text } from "./ui/Text";
 
 export default ({ id }: { id: string }) => {

--- a/front/src/components/AssetDisplay.css
+++ b/front/src/components/AssetDisplay.css
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */

--- a/front/src/components/AssetDisplay.jsx
+++ b/front/src/components/AssetDisplay.jsx
@@ -1,20 +1,16 @@
-import * as React from "react";
-import { Grid, Row, Button } from "@nextui-org/react";
-import { CONTRACTS } from "../ether/contracts";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
 
-import { getTokenNameFromAddress, truncateAddress } from "../ether/utils";
-import { FaCoins } from "react-icons/fa";
 import { useSelector } from "react-redux";
-import { ethers } from "ethers";
-import { useTokenFromList, useTokenFromNetwork } from "../hooks/token";
-import { useActionCreator } from "../state/game/hooks";
-import { TransactionType } from "../common/types";
+import { useTokenFromList } from "../hooks/token";
 import { useWeb3React } from "@web3-react/core";
 import { Text } from "./ui/Text";
-import Profile from "./Profile";
-import ProfileImage from "./ProfileImage";
 import TokenIcon from "./TokenIcon";
-import { SelectIcon } from "@radix-ui/react-select";
 import { USDC_ADDRESS_ON_NETWORKS, DEFAULT_TOKEN_URI } from "../ether/chains";
 import Flex from "./ui/Flex";
 

--- a/front/src/components/Auth.css
+++ b/front/src/components/Auth.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 .smallText {
   font-size: 10px;
   width: 200px;

--- a/front/src/components/Auth.jsx
+++ b/front/src/components/Auth.jsx
@@ -1,15 +1,21 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useModal, Modal, Row } from "@nextui-org/react";
 import { FaUser } from "react-icons/fa";
-import { toHex, truncateAddress } from "../ether/utils";
+import { truncateAddress } from "../ether/utils";
 import {
   setChainId,
   setAccounts,
-  setError,
   setIsActivating,
   setIsActive,
-  setProvider,
 } from "../state/auth/authSlice";
 import { useEffect } from "react";
 import { hooks, metaMask } from "../ether/connectors/metaMask";
@@ -20,13 +26,10 @@ import { useTime } from "./ActionView";
 import "./Auth.css";
 import AuthNetwork from "./AuthNetwork";
 import * as Separator from "@radix-ui/react-separator";
-import * as Popover from "@radix-ui/react-popover";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { styled, keyframes } from "@stitches/react";
 import { violet, mauve, blackA, red } from "@radix-ui/colors";
 import {
-  HamburgerMenuIcon,
-  DotFilledIcon,
   CheckIcon,
   ChevronRightIcon,
   ChevronDownIcon,

--- a/front/src/components/AuthNetwork.jsx
+++ b/front/src/components/AuthNetwork.jsx
@@ -1,12 +1,16 @@
-import {
-  CHAINS,
-  DEFAULT_NETWORK_URI,
-  DEFAULT_TOKEN_URI,
-} from "../ether/chains";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { CHAINS, DEFAULT_NETWORK_URI } from "../ether/chains";
 import React, { useMemo } from "react";
 import * as Select from "@radix-ui/react-select";
 import { styled } from "@stitches/react";
-import { violet, mauve, blackA } from "@radix-ui/colors";
+import { violet, mauve } from "@radix-ui/colors";
 import {
   CheckIcon,
   ChevronDownIcon,

--- a/front/src/components/Body.css
+++ b/front/src/components/Body.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 .body {
   width: 100%;
   display: flex;

--- a/front/src/components/Body.jsx
+++ b/front/src/components/Body.jsx
@@ -1,29 +1,20 @@
-import * as React from "react";
-import {
-  Row,
-  Grid,
-  Spacer,
-  Card,
-  Pagination,
-  Divider,
-  Table,
-} from "@nextui-org/react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { Spacer } from "@nextui-org/react";
 import "./Body.css";
-import { FaArrowDown, FaCoins, FaPlay } from "react-icons/fa";
 import GameList from "./list/GameList";
-import { createGame } from "../state/game/gameSlice";
-import { useDispatch } from "react-redux";
-import FileUploader from "./BotUploader";
-import ModalCreateGame from "./modals/ModalCreateGame";
-import ModalDepositToken from "./modals/ModalDepositToken";
-import { useAppSelector } from "../state/hooks";
 import Button from "./ui/Button";
 import { Text } from "./ui/Text";
 import ModalNewDepositFunds from "./modals/ModalNewDepositFunds";
 import { styled } from "@stitches/react";
 import { violet } from "@radix-ui/colors";
 import ModalNewCreateGame from "./modals/ModalNewCreateGame";
-import Separator from "./ui/Separator";
 import { useAllActiveAndCompletedGamesSeparated } from "../state/game/hooks";
 
 export default () => {

--- a/front/src/components/BotGameCreator.jsx
+++ b/front/src/components/BotGameCreator.jsx
@@ -1,13 +1,13 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as React from "react";
-import {
-  Text,
-  Table,
-  User,
-  Button,
-  Modal,
-  Input,
-  Row,
-} from "@nextui-org/react";
+import { Text, Button, Modal, Input, Row } from "@nextui-org/react";
 import { useDispatch } from "react-redux";
 import { FaRobot } from "react-icons/fa";
 import { TransactionType } from "../common/types";

--- a/front/src/components/BotManager.jsx
+++ b/front/src/components/BotManager.jsx
@@ -1,15 +1,18 @@
-import * as React from "react";
-import BotUploader from "./BotUploader";
-import { useSelector } from "react-redux";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import BotListView from "./list/BotList";
-import BotGameCreator from "./BotGameCreator";
 import { useAllBots } from "../state/game/hooks";
-import Flex from "./ui/Flex";
 import { Text } from "./ui/Text";
 import { styled } from "@stitches/react";
 import ModalCreateBot from "./modals/ModalCreateBot";
 import Separator from "./ui/Separator";
-import { ZoomOutIcon, StitchesLogoIcon } from "@radix-ui/react-icons";
+import { StitchesLogoIcon } from "@radix-ui/react-icons";
 import { violet } from "@radix-ui/colors";
 import Button from "./ui/Button";
 

--- a/front/src/components/BotMoveStatisticsView.tsx
+++ b/front/src/components/BotMoveStatisticsView.tsx
@@ -1,11 +1,16 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //create a react component that will display the statistics of the bot moves
 //takes in BotMoveStats interface as a prop
 
-import React from "react";
-
 import { BotMoveStats } from "../state/game/types";
 import Flex from "./ui/Flex";
-import Separator from "./ui/Separator";
 import { Text } from "./ui/Text";
 
 interface BotMoveStatisticsViewProps {

--- a/front/src/components/BotProfile.tsx
+++ b/front/src/components/BotProfile.tsx
@@ -1,15 +1,20 @@
-import { Button, Card, Col, Divider, Row } from "@nextui-org/react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { Button } from "@nextui-org/react";
 import { useWeb3React } from "@web3-react/core";
 import * as React from "react";
-import { useMatch, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import { USDC_ADDRESS_ON_NETWORKS } from "../ether/chains";
-import { useAllBots, useProfile } from "../state/game/hooks";
-import { BotProfile } from "../state/game/types";
-import { useAppSelector } from "../state/hooks";
+import { useAllBots } from "../state/game/hooks";
 import Address from "./Address";
 import AssetDisplay from "./AssetDisplay";
-import BotListView from "./list/BotList";
 import ChallengesList from "./list/ChallengesList";
 import GameList from "./list/GameList";
 import ModalCreateChallenge from "./modals/ModalCreateChallenge";
@@ -18,7 +23,6 @@ import ModalManageBot from "./modals/ModalManageBot";
 import OffersList from "./OffersList";
 import Date from "./ui/Date";
 import Flex from "./ui/Flex";
-import List from "./ui/List";
 import { Text } from "./ui/Text";
 
 export default () => {

--- a/front/src/components/BottomNav.jsx
+++ b/front/src/components/BottomNav.jsx
@@ -1,4 +1,11 @@
-import React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import Flex from "./ui/Flex";
 import { Text } from "./ui/Text";
 import { useLatestTimestampAndBlockNumber } from "../state/transactions/hooks";

--- a/front/src/components/Game.css
+++ b/front/src/components/Game.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 .game {
   width: 100%;
   display: flex;

--- a/front/src/components/Game.jsx
+++ b/front/src/components/Game.jsx
@@ -1,5 +1,12 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import Address from "./Address";
-import React, { useMemo } from "react";
 import { Chessboard } from "react-chessboard";
 import { Chess } from "chess.js";
 
@@ -14,25 +21,16 @@ import {
   getBottomAddress,
   getTopAddress,
   side,
-  InputStatus,
-  InputType,
 } from "../state/game/gameHelper";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useEffect, useState, useCallback } from "react";
-import { joinGame, sendMove } from "../state/game/gameSlice";
 import { TransactionType } from "../common/types";
 import GameMovesView from "./GameMovesView";
-import GameTimer from "./GameTimer";
 import {
   useActionCreator,
   useActionsNotProcessed,
-  useActions,
   useGame,
 } from "../state/game/hooks";
-import { useAllTransactions } from "../state/transactions/hooks";
-import { Row } from "@nextui-org/react";
-import { useToken } from "../hooks/token";
-import { ethers } from "ethers";
 import Flex from "./ui/Flex";
 import AssetDisplay from "./AssetDisplay";
 import { useTime } from "./ActionView";

--- a/front/src/components/GameBotMoveStatisticsHoverable.tsx
+++ b/front/src/components/GameBotMoveStatisticsHoverable.tsx
@@ -1,22 +1,17 @@
-import { mauve } from "@radix-ui/colors";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as HoverCard from "@radix-ui/react-hover-card";
 import { keyframes, styled } from "@stitches/react";
 import React from "react";
 
-import { useProfile } from "../state/game/hooks";
-import {
-  BotProfile,
-  Profile,
-  ProfileType,
-  UserProfile,
-} from "../state/game/types";
 import { BotMoveStats } from "../state/game/types";
-import Address from "./Address";
-import AssetDisplay from "./AssetDisplay";
 import BotMoveStatisticsView from "./BotMoveStatisticsView";
-import ModalCreateChallenge from "./modals/ModalCreateChallenge";
-import ModalCreateOffer from "./modals/ModalCreateOffer";
-import Button from "./ui/Button";
 import Flex from "./ui/Flex";
 import { Text } from "./ui/Text";
 

--- a/front/src/components/GameMovesView.css
+++ b/front/src/components/GameMovesView.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 td {
   background-color: #fff;
 }

--- a/front/src/components/GameMovesView.jsx
+++ b/front/src/components/GameMovesView.jsx
@@ -1,12 +1,11 @@
-import * as React from "react";
-import { Grid, Card, Divider } from "@nextui-org/react";
-import {
-  FaFastForward,
-  FaFastBackward,
-  FaForward,
-  FaBackward,
-} from "react-icons/fa";
-import { ImLoop } from "react-icons/im";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Chess } from "chess.js";
 import Separator from "./ui/Separator";
 import List from "./ui/List";

--- a/front/src/components/GameTimer.jsx
+++ b/front/src/components/GameTimer.jsx
@@ -1,5 +1,13 @@
-import * as React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Text, Card } from "@nextui-org/react";
+
 export default (props) => {
   const { secondsLeft, isActive } = props;
   const mmHhSs = new Date(secondsLeft * 1000).toISOString().slice(11, 19);

--- a/front/src/components/GameWagersView.tsx
+++ b/front/src/components/GameWagersView.tsx
@@ -1,12 +1,17 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //Takes in GameWagers interface type and renders a list of wagers use List component
 //
 import { truncateAddress } from "../ether/utils";
 import { GameWagers } from "../state/game/types";
 import Address from "./Address";
 import AssetDisplay from "./AssetDisplay";
-import ModalPlaceBet from "./modals/ModalPlaceBet";
-import Button from "./ui/Button";
-import Date from "./ui/Date";
 import Flex from "./ui/Flex";
 import List from "./ui/List";
 import { Text } from "./ui/Text";

--- a/front/src/components/HandleChallenge.tsx
+++ b/front/src/components/HandleChallenge.tsx
@@ -1,4 +1,10 @@
-import React, { useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
 
 import {
   AcceptChallengeTransactionsInfo,

--- a/front/src/components/HandleOffer.tsx
+++ b/front/src/components/HandleOffer.tsx
@@ -1,10 +1,16 @@
-import React, { useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { useState } from "react";
 
 import {
   AcceptBotOfferTransactionsInfo,
-  AcceptChallengeTransactionsInfo,
   DeclineBotOfferTransactionsInfo,
-  DeclineChallengeTransactionsInfo,
   TransactionType,
 } from "../common/types";
 import { useActionCreator } from "../state/game/hooks";

--- a/front/src/components/Navbar.css
+++ b/front/src/components/Navbar.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 nav {
   top: 0; /* Stick it to the top */
   max-height: 100px;

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -1,7 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as React from "react";
 import Auth from "./Auth";
-import Title from "./Title";
-import { Spacer, Button } from "@nextui-org/react";
+import { Button } from "@nextui-org/react";
 import "./Navbar.css";
 import { Link } from "react-router-dom";
 import logo from "../assets/horse.png";

--- a/front/src/components/NotificationDropdown.jsx
+++ b/front/src/components/NotificationDropdown.jsx
@@ -1,14 +1,15 @@
-import React, { useEffect } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { styled, keyframes } from "@stitches/react";
 import { violet, mauve, blackA } from "@radix-ui/colors";
-import {
-  HamburgerMenuIcon,
-  DotFilledIcon,
-  CheckIcon,
-  ChevronRightIcon,
-  BellIcon,
-} from "@radix-ui/react-icons";
+import { BellIcon } from "@radix-ui/react-icons";
 import { useNotifications } from "../state/notifications/hooks";
 import NotificationItem from "./NotificationItem";
 

--- a/front/src/components/NotificationItem.tsx
+++ b/front/src/components/NotificationItem.tsx
@@ -1,10 +1,16 @@
-import { blackA, green, mauve, slate, violet } from "@radix-ui/colors";
-import * as Toast from "@radix-ui/react-toast";
-import { keyframes, styled } from "@stitches/react";
-import { useWeb3React } from "@web3-react/core";
-import * as React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
 
-import { useUserBotIds } from "../state/game/hooks";
+import { slate } from "@radix-ui/colors";
+import * as Toast from "@radix-ui/react-toast";
+import { styled } from "@stitches/react";
+import { useWeb3React } from "@web3-react/core";
+
 import {
   Notification,
   NotificationType,

--- a/front/src/components/Notifications.tsx
+++ b/front/src/components/Notifications.tsx
@@ -1,15 +1,19 @@
-import { blackA, green, mauve, slate, violet } from "@radix-ui/colors";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { blackA, green, mauve, violet } from "@radix-ui/colors";
 import * as Toast from "@radix-ui/react-toast";
 import { keyframes, styled } from "@stitches/react";
 import * as React from "react";
 
-import {
-  useNewNotifications,
-  useNotifications,
-} from "../state/notifications/hooks";
+import { useNotifications } from "../state/notifications/hooks";
 import { NotificationType } from "../state/notifications/notifications";
 import { NOTIFICATION_TOAST_DURATION_MILLIS } from "../utils/constants";
-import { useTime } from "./ActionView";
 import NotificationItem from "./NotificationItem";
 
 const Notifications = () => {

--- a/front/src/components/OffersList.tsx
+++ b/front/src/components/OffersList.tsx
@@ -1,13 +1,15 @@
-import { useWeb3React } from "@web3-react/core";
-import * as React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
 
-import { formatDate, truncateAddress } from "../ether/utils";
 import { BotOffer } from "../state/game/types";
 import Address from "./Address";
 import AssetDisplay from "./AssetDisplay";
 import HandleOffer from "./HandleOffer";
-import ModalChallengeBot from "./modals/ModalChallengeBot";
-import ModalManageBot from "./modals/ModalManageBot";
 import Date from "./ui/Date";
 import List from "./ui/List";
 import { Text } from "./ui/Text";

--- a/front/src/components/PageKingOfTheHill.tsx
+++ b/front/src/components/PageKingOfTheHill.tsx
@@ -1,35 +1,28 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { violet } from "@radix-ui/colors";
-import { StitchesLogoIcon, ZoomOutIcon } from "@radix-ui/react-icons";
 import { styled } from "@stitches/react";
 import { useWeb3React } from "@web3-react/core";
-import * as React from "react";
-import { useSelector } from "react-redux";
 
 import { USDC_ADDRESS_ON_NETWORKS } from "../ether/chains";
 import { truncateAddress } from "../ether/utils";
-import {
-  useTokenBalance,
-  useTokenFromList,
-  useTokenPortalBalance,
-} from "../hooks/token";
-import { useAllTournaments, useThrone } from "../state/game/hooks";
+import { useTokenFromList } from "../hooks/token";
+import { useThrone } from "../state/game/hooks";
 import { ThroneBattle } from "../state/game/types";
 import Address from "./Address";
 import AddressGame from "./AddressGame";
 import AssetDisplay from "./AssetDisplay";
-import BotGameCreator from "./BotGameCreator";
-import BotUploader from "./BotUploader";
-import BotListView from "./list/BotList";
-import ProfileList from "./list/ProfileList";
-import TournamentList from "./list/TournamentList";
-import ModalCreateBot from "./modals/ModalCreateBot";
-import ModalCreateTournament from "./modals/ModalCreateTournament";
 import ModalThroneChallenge from "./modals/ModalThroneChallenge";
 import ModalThroneUpdate from "./modals/ModalThroneUpdate";
 import Button from "./ui/Button";
 import Flex from "./ui/Flex";
 import List from "./ui/List";
-import Separator from "./ui/Separator";
 import { Text } from "./ui/Text";
 
 const battleListItem = (

--- a/front/src/components/Profile.css
+++ b/front/src/components/Profile.css
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */

--- a/front/src/components/Profile.tsx
+++ b/front/src/components/Profile.tsx
@@ -1,23 +1,24 @@
-import { Button, Card, Col, Divider, Row } from "@nextui-org/react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { Button } from "@nextui-org/react";
 import { useWeb3React } from "@web3-react/core";
-import * as React from "react";
-import { useMatch, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import { USDC_ADDRESS_ON_NETWORKS } from "../ether/chains";
 import { useProfile } from "../state/game/hooks";
-import { UserProfile } from "../state/game/types";
-import { useAppSelector } from "../state/hooks";
 import Address from "./Address";
 import AssetDisplay from "./AssetDisplay";
 import BotListView from "./list/BotList";
 import ChallengesList from "./list/ChallengesList";
 import GameList from "./list/GameList";
 import ModalCreateChallenge from "./modals/ModalCreateChallenge";
-import ModalManageBot from "./modals/ModalManageBot";
-import OffersList from "./OffersList";
-import Date from "./ui/Date";
 import Flex from "./ui/Flex";
-import List from "./ui/List";
 import { Text } from "./ui/Text";
 
 export default () => {

--- a/front/src/components/ProfileHover.tsx
+++ b/front/src/components/ProfileHover.tsx
@@ -1,20 +1,19 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { mauve } from "@radix-ui/colors";
 import * as HoverCard from "@radix-ui/react-hover-card";
 import { keyframes, styled } from "@stitches/react";
-import React from "react";
 
 import { useProfile } from "../state/game/hooks";
-import {
-  BotProfile,
-  Profile,
-  ProfileType,
-  UserProfile,
-} from "../state/game/types";
+import { BotProfile, ProfileType, UserProfile } from "../state/game/types";
 import Address from "./Address";
 import AssetDisplay from "./AssetDisplay";
-import ModalCreateChallenge from "./modals/ModalCreateChallenge";
-import ModalCreateOffer from "./modals/ModalCreateOffer";
-import Button from "./ui/Button";
 
 const BotProfileCard = ({ profile }: { profile: BotProfile }) => {
   //console.log("123 bot profile", profile)

--- a/front/src/components/ProfileImage.jsx
+++ b/front/src/components/ProfileImage.jsx
@@ -1,9 +1,14 @@
-import React, { useMemo, useRef } from "react";
-import { Text, Grid, User } from "@nextui-org/react";
-import { truncateAddress } from "../ether/utils";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { useMemo } from "react";
 import { createIcon } from "@download/blockies";
 import "./Address.css";
-import { Link } from "react-router-dom";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { styled } from "@stitches/react";
 import { violet, blackA } from "@radix-ui/colors";

--- a/front/src/components/Rankings.tsx
+++ b/front/src/components/Rankings.tsx
@@ -1,14 +1,21 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import "./Address.css";
+
 import { violet } from "@radix-ui/colors";
-import { StitchesLogoIcon, ZoomOutIcon } from "@radix-ui/react-icons";
+import { StitchesLogoIcon } from "@radix-ui/react-icons";
 import { styled } from "@stitches/react";
-import * as React from "react";
-import { useSelector } from "react-redux";
 
 import { useAllProfiles } from "../state/game/hooks";
 import ProfileList from "./list/ProfileList";
 import ModalCreateBot from "./modals/ModalCreateBot";
 import Button from "./ui/Button";
-import Flex from "./ui/Flex";
 import Separator from "./ui/Separator";
 import { Text } from "./ui/Text";
 

--- a/front/src/components/Title.jsx
+++ b/front/src/components/Title.jsx
@@ -1,5 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as React from "react";
-import { Text, Grid } from "@nextui-org/react";
+import { Text } from "@nextui-org/react";
+
 export default () => {
   const [mainItems, setMainItems] = React.useState([]);
   return <Text size={40}>Ultrachess</Text>;

--- a/front/src/components/TokenIcon.jsx
+++ b/front/src/components/TokenIcon.jsx
@@ -1,9 +1,12 @@
-import React, { useMemo, useRef } from "react";
-import { Text, Grid, User } from "@nextui-org/react";
-import { truncateAddress } from "../ether/utils";
-import { createIcon } from "@download/blockies";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import "./Address.css";
-import { Link } from "react-router-dom";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { styled } from "@stitches/react";
 import { violet, blackA } from "@radix-ui/colors";

--- a/front/src/components/TournamentView.tsx
+++ b/front/src/components/TournamentView.tsx
@@ -1,15 +1,17 @@
-import {
-  Match,
-  SingleEliminationBracket,
-  SVGViewer,
-} from "@g-loot/react-tournament-brackets";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { violet } from "@radix-ui/colors";
 import { styled } from "@stitches/react";
 import { useMemo } from "react";
 import { useParams } from "react-router-dom";
 
 import { useTournament } from "../state/game/hooks";
-import { TournamentMatch } from "../state/game/types";
 import TournamentRoundView from "./list/TournamentRoundView";
 import ModalJoinTournament from "./modals/ModalJoinTournament";
 import Button from "./ui/Button";

--- a/front/src/components/Tournaments.jsx
+++ b/front/src/components/Tournaments.jsx
@@ -1,18 +1,18 @@
-import * as React from "react";
-import BotUploader from "./BotUploader";
-import { useSelector } from "react-redux";
-import BotListView from "./list/BotList";
-import BotGameCreator from "./BotGameCreator";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { useAllTournaments } from "../state/game/hooks";
-import Flex from "./ui/Flex";
 import { Text } from "./ui/Text";
 import { styled } from "@stitches/react";
-import ModalCreateBot from "./modals/ModalCreateBot";
 import Separator from "./ui/Separator";
-import { ZoomOutIcon, StitchesLogoIcon } from "@radix-ui/react-icons";
+import { StitchesLogoIcon } from "@radix-ui/react-icons";
 import Button from "./ui/Button";
 import { violet } from "@radix-ui/colors";
-import ProfileList from "./list/ProfileList";
 import ModalCreateTournament from "./modals/ModalCreateTournament";
 import TournamentList from "./list/TournamentList";
 

--- a/front/src/components/TransitionManager.css
+++ b/front/src/components/TransitionManager.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 #overlay {
   position: fixed;
   top: 0;

--- a/front/src/components/TransitionManager.tsx
+++ b/front/src/components/TransitionManager.tsx
@@ -1,11 +1,18 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import "./TransitionManager.css";
 
-import { Grid, Loading, Text } from "@nextui-org/react";
-import React, { useMemo } from "react";
+import { Loading, Text } from "@nextui-org/react";
+import { useMemo } from "react";
 
 import { TransactionType } from "../common/types";
 import { useActionsNotProcessed } from "../state/game/hooks";
-import { useAllTransactions } from "../state/transactions/hooks";
 
 export default () => {
   const actionsNotProcessed = useActionsNotProcessed();

--- a/front/src/components/UserItem.jsx
+++ b/front/src/components/UserItem.jsx
@@ -1,5 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { User, Text } from "@nextui-org/react";
 import { truncateAddress } from "../ether/utils";
+
 export default (props) => {
   var { white } = props;
   var address = "0xD319edC71026080c2F4c320ab19A8Dc06e90623e";

--- a/front/src/components/UserList.tsx
+++ b/front/src/components/UserList.tsx
@@ -1,14 +1,12 @@
-import {
-  Button,
-  Card,
-  Divider,
-  Grid,
-  Pagination,
-  Row,
-  Spacer,
-  Table,
-  Text,
-} from "@nextui-org/react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { Table, Text } from "@nextui-org/react";
 
 import { useAppSelector } from "../state/hooks";
 import Address from "./Address";

--- a/front/src/components/list/BotList.tsx
+++ b/front/src/components/list/BotList.tsx
@@ -1,10 +1,12 @@
-import { useWeb3React } from "@web3-react/core";
-import * as React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
 
-import { formatDate, truncateAddress } from "../../ether/utils";
 import { BotProfile } from "../../state/game/types";
-import Address from "../Address";
-import ModalChallengeBot from "../modals/ModalChallengeBot";
 import List from "../ui/List";
 import { Text } from "../ui/Text";
 import BotListItem from "./BotListItem";

--- a/front/src/components/list/BotListItem.tsx
+++ b/front/src/components/list/BotListItem.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //React component that takes in BotProfile and renders it with multiple Flex components
 
 import { BotProfile } from "../../state/game/types";

--- a/front/src/components/list/ChallengesList.tsx
+++ b/front/src/components/list/ChallengesList.tsx
@@ -1,7 +1,11 @@
-import { useWeb3React } from "@web3-react/core";
-import * as React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
 
-import { formatDate, truncateAddress } from "../../ether/utils";
 import { useOwner } from "../../state/game/hooks";
 import { Challenge } from "../../state/game/types";
 import Address from "../Address";

--- a/front/src/components/list/GameList.tsx
+++ b/front/src/components/list/GameList.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Game } from "../../state/game/types";
 import List from "../ui/List";
 import { Text } from "../ui/Text";

--- a/front/src/components/list/GameListItem.tsx
+++ b/front/src/components/list/GameListItem.tsx
@@ -1,6 +1,13 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { DotIcon, LockClosedIcon } from "@radix-ui/react-icons";
 import { useWeb3React } from "@web3-react/core";
-import * as React from "react";
 
 import { Game } from "../../state/game/types";
 import { useTime } from "../ActionView";

--- a/front/src/components/list/LpNftList.tsx
+++ b/front/src/components/list/LpNftList.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { LpNftProfile } from "../../state/game/types";
+import List from "../ui/List";
+import { Text } from "../ui/Text";
+import LpNftListItem from "./LpNftListItem";
+
+export default ({ lpNfts }: { lpNfts: LpNftProfile[] }) => {
+  const lpNftItems =
+    lpNfts.length > 0
+      ? lpNfts.map((lpNft) => <LpNftListItem lpNft={lpNft} />)
+      : [<Text key={0}>No LP NFTs found</Text>];
+
+  return <List items={lpNftItems} />;
+};

--- a/front/src/components/list/LpNftListItem.tsx
+++ b/front/src/components/list/LpNftListItem.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+// React component that takes in LpNftProfile and renders it with multiple
+// Flex components
+
+import { LpNftProfile } from "../../state/game/types";
+import Flex from "../ui/Flex";
+import { Text } from "../ui/Text";
+
+export default ({ lpNft }: { lpNft: LpNftProfile }) => {
+  const { tokenId, name, description, imageUri } = lpNft;
+
+  return (
+    <Flex css={{ gap: 5, justifyContent: "space-between" }}>
+      <Flex css={{ flexDirection: "column", gap: 2 }}>
+        <Text faded>Token ID</Text>
+        <Text>{tokenId.toString()}</Text>
+      </Flex>
+      <Flex css={{ flexDirection: "column", gap: 2 }}>
+        <Text faded>Name</Text>
+        <Text>{name}</Text>
+      </Flex>
+      <Flex css={{ flexDirection: "column", gap: 2 }}>
+        <Text faded>URI</Text>
+        <img src={imageUri}></img>
+      </Flex>
+    </Flex>
+  );
+};

--- a/front/src/components/list/ProfileList.tsx
+++ b/front/src/components/list/ProfileList.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Profile } from "../../state/game/types";
 import List from "../ui/List";
 import { Text } from "../ui/Text";

--- a/front/src/components/list/ProfileListItem.tsx
+++ b/front/src/components/list/ProfileListItem.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //React component that takes in BotProfile and renders it with multiple Flex components
 
 import { Profile, ProfileType, UserProfile } from "../../state/game/types";

--- a/front/src/components/list/TournamentList.tsx
+++ b/front/src/components/list/TournamentList.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //renders list of tournaments.
 
 // Path: front/src/components/list/TournamentList.tsx
@@ -6,19 +14,7 @@
 
 // //This component takes in an array of Tournament objects and renders them within a list
 
-import { DotIcon } from "@radix-ui/react-icons";
-import { useWeb3React } from "@web3-react/core";
-
-import {
-  Tournament,
-  TournamentMatch,
-  TournamentRound,
-  TournamentType,
-} from "../../state/game/types";
-import Address from "../Address";
-import AssetDisplay from "../AssetDisplay";
-import DateDisplay from "../ui/Date";
-import Flex from "../ui/Flex";
+import { Tournament } from "../../state/game/types";
 import List from "../ui/List";
 import { Text } from "../ui/Text";
 import TournamentListItem from "./TournamentListItem";

--- a/front/src/components/list/TournamentListItem.tsx
+++ b/front/src/components/list/TournamentListItem.tsx
@@ -1,18 +1,19 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //This component takes in a Tournament object and renders it with multiple Flex components
 //
 import { DotIcon } from "@radix-ui/react-icons";
 import { useWeb3React } from "@web3-react/core";
 
-import {
-  Tournament,
-  TournamentMatch,
-  TournamentRound,
-  TournamentType,
-} from "../../state/game/types";
+import { Tournament } from "../../state/game/types";
 import Address from "../Address";
 import AddressTournament from "../AddressTournament";
-import AssetDisplay from "../AssetDisplay";
-import DateDisplay from "../ui/Date";
 import Flex from "../ui/Flex";
 import { Text } from "../ui/Text";
 

--- a/front/src/components/list/TournamentMatchListItem.tsx
+++ b/front/src/components/list/TournamentMatchListItem.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { TournamentMatch } from "../../state/game/types";
 import Address from "../Address";
 import AddressGame from "../AddressGame";

--- a/front/src/components/list/TournamentRoundView.tsx
+++ b/front/src/components/list/TournamentRoundView.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { TournamentMatch } from "../../state/game/types";
 import List from "../ui/List";
 import { Text } from "../ui/Text";

--- a/front/src/components/list/UserProfileListItem.tsx
+++ b/front/src/components/list/UserProfileListItem.tsx
@@ -1,13 +1,19 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //React component that takes in BotProfile and renders it with multiple Flex components
 
-import { DotIcon } from "@radix-ui/react-icons";
 import { useWeb3React } from "@web3-react/core";
 
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
-import { Profile, ProfileType, UserProfile } from "../../state/game/types";
+import { UserProfile } from "../../state/game/types";
 import Address from "../Address";
 import AssetDisplay from "../AssetDisplay";
-import DateDisplay from "../ui/Date";
 import Flex from "../ui/Flex";
 import { Text } from "../ui/Text";
 

--- a/front/src/components/modals/ModalChallengeBot.jsx
+++ b/front/src/components/modals/ModalChallengeBot.jsx
@@ -1,13 +1,18 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as React from "react";
-import { Text, Grid, Modal, Input, Row, Button } from "@nextui-org/react";
+import { Text, Modal, Input, Row, Button } from "@nextui-org/react";
 import { useDispatch, useSelector } from "react-redux";
-import { createBotGame } from "../../state/game/gameSlice";
 import { FaCoins } from "react-icons/fa";
-import { useAppSelector } from "../../state/hooks";
 import { useWeb3React } from "@web3-react/core";
 import { isAddress } from "../../utils";
 import { useActionCreator } from "../../state/game/hooks";
-import { useCallback, useEffect, useMemo } from "react";
 import Select from "react-select";
 import { TransactionType } from "../../common/types";
 import { ethers } from "ethers";

--- a/front/src/components/modals/ModalCreateBot.tsx
+++ b/front/src/components/modals/ModalCreateBot.tsx
@@ -1,10 +1,18 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //create a modal that takes in a trigger element and renders a modal with a form to create a bot
 //then makes a CREATE_BOT action to the backend
 import { blackA, green, mauve, violet } from "@radix-ui/colors";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { keyframes, styled } from "@stitches/react";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { TransactionType } from "../../common/types";
 import { useActionCreator } from "../../state/game/hooks";

--- a/front/src/components/modals/ModalCreateChallenge.jsx
+++ b/front/src/components/modals/ModalCreateChallenge.jsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import React, { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";
@@ -10,11 +18,7 @@ import {
 } from "@radix-ui/react-icons";
 import * as Slider from "@radix-ui/react-slider";
 import { Text } from "../ui/Text";
-import {
-  useTokenFromList,
-  useTokenPortalBalance,
-  useTokenBalance,
-} from "../../hooks/token";
+import { useTokenFromList, useTokenPortalBalance } from "../../hooks/token";
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
 import AssetDisplay from "../AssetDisplay";
 import { useWeb3React } from "@web3-react/core";

--- a/front/src/components/modals/ModalCreateGame.jsx
+++ b/front/src/components/modals/ModalCreateGame.jsx
@@ -1,10 +1,16 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as React from "react";
-import { Text, Grid, Modal, Input, Row, Button } from "@nextui-org/react";
+import { Text, Modal, Input, Row, Button } from "@nextui-org/react";
 import { useDispatch } from "react-redux";
-import { createGame } from "../../state/game/gameSlice";
 import { FaCoins } from "react-icons/fa";
 import { useActionCreator } from "../../state/game/hooks";
-import { TransactionTypes } from "ethers/lib/utils";
 import { TransactionType } from "../../common/types";
 import { useNavigate } from "react-router-dom";
 import { ethers } from "ethers";

--- a/front/src/components/modals/ModalCreateOffer.tsx
+++ b/front/src/components/modals/ModalCreateOffer.tsx
@@ -1,19 +1,22 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { blackA, green, mauve, violet } from "@radix-ui/colors";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import * as Slider from "@radix-ui/react-slider";
 import { keyframes, styled } from "@stitches/react";
 import { useWeb3React } from "@web3-react/core";
-import { ethers } from "ethers";
-import React, { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { TransactionType } from "../../common/types";
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
-import {
-  useTokenBalance,
-  useTokenFromList,
-  useTokenPortalBalance,
-} from "../../hooks/token";
+import { useTokenFromList, useTokenPortalBalance } from "../../hooks/token";
 import { useActionCreator } from "../../state/game/hooks";
 import Address from "../Address";
 import AssetDisplay from "../AssetDisplay";

--- a/front/src/components/modals/ModalCreateTournament.jsx
+++ b/front/src/components/modals/ModalCreateTournament.jsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import React, { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";
@@ -10,13 +18,6 @@ import {
 } from "@radix-ui/react-icons";
 import * as Slider from "@radix-ui/react-slider";
 import { Text } from "../ui/Text";
-import {
-  useTokenFromList,
-  useTokenPortalBalance,
-  useTokenBalance,
-} from "../../hooks/token";
-import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
-import AssetDisplay from "../AssetDisplay";
 import { useWeb3React } from "@web3-react/core";
 import { useActionCreator, useUserBots } from "../../state/game/hooks";
 import { TransactionType } from "../../common/types";

--- a/front/src/components/modals/ModalDepositToken.jsx
+++ b/front/src/components/modals/ModalDepositToken.jsx
@@ -1,21 +1,21 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as React from "react";
-import {
-  Text,
-  Grid,
-  Modal,
-  Input,
-  Row,
-  Button,
-  Dropdown,
-} from "@nextui-org/react";
+import { Text, Modal, Input, Row, Button } from "@nextui-org/react";
 import { useDispatch } from "react-redux";
-import { hooks, metaMask } from "../../ether/connectors/metaMask";
+import { hooks } from "../../ether/connectors/metaMask";
 const { useProvider } = hooks;
 import { FaCoins } from "react-icons/fa";
 import { TransactionType } from "../../common/types";
 import { useActionCreator } from "../../state/game/hooks";
 import { truncateAddress } from "../../ether/utils";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import Select from "react-select";
 import { useTokenList } from "../../hooks/token";
 

--- a/front/src/components/modals/ModalJoinTournament.jsx
+++ b/front/src/components/modals/ModalJoinTournament.jsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import React, { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";
@@ -10,18 +18,13 @@ import {
 } from "@radix-ui/react-icons";
 import * as Slider from "@radix-ui/react-slider";
 import { Text } from "../ui/Text";
-import {
-  useTokenFromList,
-  useTokenPortalBalance,
-  useTokenBalance,
-} from "../../hooks/token";
+import { useTokenFromList, useTokenPortalBalance } from "../../hooks/token";
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
 import { useWeb3React } from "@web3-react/core";
 import { useActionCreator, useUserBotIds } from "../../state/game/hooks";
 import { TransactionType } from "../../common/types";
 import Address from "../Address";
 import * as Select from "@radix-ui/react-select";
-import { ethers } from "ethers";
 
 export default ({ triggerElement, tournamentId }) => {
   const { chainId, account } = useWeb3React();

--- a/front/src/components/modals/ModalManageBot.jsx
+++ b/front/src/components/modals/ModalManageBot.jsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import React, { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";
@@ -16,11 +24,9 @@ import {
   useTokenBalance,
 } from "../../hooks/token";
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
-import AssetDisplay from "../AssetDisplay";
 import { useWeb3React } from "@web3-react/core";
-import { useActionCreator, useProfile } from "../../state/game/hooks";
+import { useActionCreator } from "../../state/game/hooks";
 import { TransactionType } from "../../common/types";
-import { ethers } from "ethers";
 import { useNavigate } from "react-router-dom";
 import * as Select from "@radix-ui/react-select";
 

--- a/front/src/components/modals/ModalNewCreateGame.jsx
+++ b/front/src/components/modals/ModalNewCreateGame.jsx
@@ -1,17 +1,23 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import * as Slider from "@radix-ui/react-slider";
-import { Text } from "../ui/Text";
 import {
   useTokenFromList,
   useTokenPortalBalance,
   useTokenBalance,
 } from "../../hooks/token";
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
-import AssetDisplay from "../AssetDisplay";
 import { useWeb3React } from "@web3-react/core";
 import { useActionCreator } from "../../state/game/hooks";
 import { TransactionType } from "../../common/types";

--- a/front/src/components/modals/ModalNewDepositFunds.jsx
+++ b/front/src/components/modals/ModalNewDepositFunds.jsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";

--- a/front/src/components/modals/ModalPlaceBet.jsx
+++ b/front/src/components/modals/ModalPlaceBet.jsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { useActionCreator, useGame } from "../../state/game/hooks";
 import { TransactionType } from "../../common/types";
 import { ethers } from "ethers";

--- a/front/src/components/modals/ModalThroneChallenge.jsx
+++ b/front/src/components/modals/ModalThroneChallenge.jsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import React, { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";
@@ -10,13 +18,8 @@ import {
 } from "@radix-ui/react-icons";
 import * as Slider from "@radix-ui/react-slider";
 import { Text } from "../ui/Text";
-import {
-  useTokenFromList,
-  useTokenPortalBalance,
-  useTokenBalance,
-} from "../../hooks/token";
+import { useTokenFromList } from "../../hooks/token";
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
-import AssetDisplay from "../AssetDisplay";
 import { useWeb3React } from "@web3-react/core";
 import {
   useActionCreator,
@@ -26,7 +29,6 @@ import {
 import { TransactionType } from "../../common/types";
 import Address from "../Address";
 import * as Select from "@radix-ui/react-select";
-import { ethers } from "ethers";
 
 export default ({ triggerElement }) => {
   const { chainId, account } = useWeb3React();

--- a/front/src/components/modals/ModalThroneUpdate.jsx
+++ b/front/src/components/modals/ModalThroneUpdate.jsx
@@ -1,20 +1,22 @@
-import React, { useEffect, useState } from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { styled, keyframes } from "@stitches/react";
 import { violet, blackA, mauve, green } from "@radix-ui/colors";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import * as Slider from "@radix-ui/react-slider";
-import {
-  useTokenFromList,
-  useTokenPortalBalance,
-  useTokenBalance,
-} from "../../hooks/token";
+import { useTokenFromList } from "../../hooks/token";
 import { USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
 import { useWeb3React } from "@web3-react/core";
 import { useActionCreator } from "../../state/game/hooks";
 import { TransactionType } from "../../common/types";
-import { ethers } from "ethers";
-import { useNavigate } from "react-router-dom";
 import { useThrone } from "../../state/game/hooks";
 
 export default ({ triggerElement }) => {

--- a/front/src/components/ui/Button.jsx
+++ b/front/src/components/ui/Button.jsx
@@ -1,4 +1,11 @@
-import React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { styled } from "@stitches/react";
 import { violet, mauve, red, blackA, whiteA } from "@radix-ui/colors";
 import { blue } from "@nextui-org/react";

--- a/front/src/components/ui/Date.tsx
+++ b/front/src/components/ui/Date.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Text } from "./Text";
 //current must be in seconds
 

--- a/front/src/components/ui/Flex.tsx
+++ b/front/src/components/ui/Flex.tsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { styled } from "@stitches/react";
 
 const Flex = styled("div", { display: "flex" });

--- a/front/src/components/ui/List.tsx
+++ b/front/src/components/ui/List.tsx
@@ -1,7 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { blackA, mauve, violet } from "@radix-ui/colors";
 import * as ScrollArea from "@radix-ui/react-scroll-area";
 import { styled } from "@stitches/react";
-import React from "react";
 
 const List = ({ items }) => (
   <ScrollAreaRoot>

--- a/front/src/components/ui/Separator.tsx
+++ b/front/src/components/ui/Separator.tsx
@@ -1,4 +1,12 @@
-import { mauve, violet } from "@radix-ui/colors";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { mauve } from "@radix-ui/colors";
 import * as Separator from "@radix-ui/react-separator";
 import { styled } from "@stitches/react";
 

--- a/front/src/components/ui/Text.jsx
+++ b/front/src/components/ui/Text.jsx
@@ -1,4 +1,11 @@
-import React from "react";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { styled } from "@stitches/react";
 import { violet, mauve, blueA, blackA, greenA } from "@radix-ui/colors";
 

--- a/front/src/ether/chains.js
+++ b/front/src/ether/chains.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import CartesiToken from "../../../deployments/localhost/CartesiToken.json";
 
 const ETH = {

--- a/front/src/ether/connectors/coinBase.js
+++ b/front/src/ether/connectors/coinBase.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { CoinbaseWallet } from "@web3-react/coinbase-wallet";
 import { initializeConnector } from "@web3-react/core";
 

--- a/front/src/ether/connectors/metaMask.js
+++ b/front/src/ether/connectors/metaMask.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { initializeConnector } from "@web3-react/core";
 import { MetaMask } from "@web3-react/metamask";
 

--- a/front/src/ether/connectors/walletConnect.js
+++ b/front/src/ether/connectors/walletConnect.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { initializeConnector } from "@web3-react/core";
 import { WalletConnect } from "@web3-react/walletconnect";
 

--- a/front/src/ether/contracts.js
+++ b/front/src/ether/contracts.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import * as ERC20PortalFacetArbitrumGoerli from "@cartesi/rollups/deployments/arbitrum_goerli/ERC20PortalFacet.json";
 import * as ERC20PortalFacetOptimismGoerli from "@cartesi/rollups/deployments/arbitrum_goerli/ERC20PortalFacet.json";
 import * as ERC20PortalFacetPolygonMumbai from "@cartesi/rollups/deployments/arbitrum_goerli/ERC20PortalFacet.json";

--- a/front/src/ether/networks.js
+++ b/front/src/ether/networks.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 export const networks = [
   {
     chainId: 31337,

--- a/front/src/ether/utils.js
+++ b/front/src/ether/utils.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { CONTRACTS } from "../ether/contracts";
 
 export const truncateAddress = (address) => {

--- a/front/src/generated-src/graphql/index.ts
+++ b/front/src/generated-src/graphql/index.ts
@@ -1,4 +1,13 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {

--- a/front/src/graphql/queries.graphql
+++ b/front/src/graphql/queries.graphql
@@ -1,3 +1,15 @@
+# Copyright 2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 query GetNotice($query: NoticeKeys) {
   GetNotice(query: $query) {
     session_id

--- a/front/src/graphql/schema.graphql
+++ b/front/src/graphql/schema.graphql
@@ -1,3 +1,15 @@
+# Copyright 2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 # Query types
 type Version {
   id: Int!

--- a/front/src/hooks/contract.ts
+++ b/front/src/hooks/contract.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Contract } from "@ethersproject/contracts";
 import { useWeb3React } from "@web3-react/core";
 import { useEffect, useMemo, useState } from "react";

--- a/front/src/hooks/token.ts
+++ b/front/src/hooks/token.ts
@@ -1,9 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { useWeb3React } from "@web3-react/core";
 import { useEffect, useMemo, useState } from "react";
-import { useSelector } from "react-redux";
 
-import { useAppSelector } from "../state/hooks";
-import { COINGECKO_LIST, fetchTokenList } from "../utils/lists";
 import ULTRACHESS_LIST from "../utils/lists/ultrachess.tokenlists.json";
 import { useContractCallResult, useErc20Contract } from "./contract";
 

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;

--- a/front/src/main.jsx
+++ b/front/src/main.jsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
@@ -5,10 +13,8 @@ import { NextUIProvider } from "@nextui-org/react";
 import { store } from "./state/index";
 import { Provider } from "react-redux";
 import { Web3ReactProvider } from "@web3-react/core";
-import { ethers } from "ethers";
 import { BrowserRouter as Router } from "react-router-dom";
 import { metaMask, hooks as metaMaskHooks } from "./ether/connectors/metaMask";
-import { TransactionUpdater } from "./state/transactions/updater";
 
 const connectors = [[metaMask, metaMaskHooks]];
 

--- a/front/src/state/actions/reducer.ts
+++ b/front/src/state/actions/reducer.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { createSlice } from "@reduxjs/toolkit";
 
 import { Action } from "../game/types";

--- a/front/src/state/auth/authSlice.js
+++ b/front/src/state/auth/authSlice.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { createSlice } from "@reduxjs/toolkit";
 
 export const authSlice = createSlice({

--- a/front/src/state/game/gameHelper.js
+++ b/front/src/state/game/gameHelper.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Chess } from "chess.js";
 
 export const InputType = {

--- a/front/src/state/game/gameSlice.js
+++ b/front/src/state/game/gameSlice.js
@@ -1,9 +1,15 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { createSlice } from "@reduxjs/toolkit";
-import { createClient, defaultExchanges } from "@urql/core";
 import { default as axios } from "axios";
 import { Chess } from "chess.js";
 import { ethers } from "ethers";
-import { pipe, subscribe } from "wonka";
 
 import dappGoerli from "../../../../deployments/goerli/chessAppNew.json";
 import dappLocalhost from "../../../../deployments/localhost/dapp.json";
@@ -13,7 +19,6 @@ import { CONTRACTS } from "../../ether/contracts";
 import {
   createDummyGames,
   createGameHelper,
-  getGameById,
   getGameByPlayer,
   InputStatus,
   InputType,

--- a/front/src/state/game/hooks.ts
+++ b/front/src/state/game/hooks.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { TransactionResponse } from "@ethersproject/providers";
 import { useWeb3React } from "@web3-react/core";
 import { ethers } from "ethers";
@@ -5,14 +13,10 @@ import { useCallback, useMemo } from "react";
 import { useDispatch } from "react-redux";
 
 import { TransactionInfo, TransactionType } from "../../common/types";
-import { CHAINS, USDC_ADDRESS_ON_NETWORKS } from "../../ether/chains";
+import { CHAINS } from "../../ether/chains";
 import { CONTRACTS } from "../../ether/contracts";
-import { useContract, useErc20Contract } from "../../hooks/contract";
-import {
-  appendNumberToUInt8Array,
-  decimalToHexString,
-  getErc20Contract,
-} from "../../utils";
+import { useContract } from "../../hooks/contract";
+import { appendNumberToUInt8Array, getErc20Contract } from "../../utils";
 import {
   addAction,
   setAction,
@@ -21,11 +25,9 @@ import {
 import { useAppSelector } from "../hooks";
 import {
   ActionNotification,
-  Notification,
   NotificationType,
 } from "../notifications/notifications";
 import { addNotification } from "../notifications/reducer";
-import { useTransactionAdder } from "../transactions/hooks";
 import { useTransactionAdder } from "../transactions/hooks";
 import { createPromise } from "./gameHelper";
 import { DAPP_ADDRESSES } from "./gameSlice";
@@ -40,31 +42,12 @@ import {
   BotOffer,
   BotProfile,
   Challenge,
-  Country,
   Game,
   Profile,
   ProfileType,
   Throne,
   Tournament,
   TournamentType,
-  UserProfile,
-} from "./types";
-import {
-  Action,
-  ActionList,
-  ActionStates,
-  ActionType,
-  Balance,
-  BaseProfile,
-  Bet,
-  BotOffer,
-  BotProfile,
-  Challenge,
-  Country,
-  Game,
-  Profile,
-  ProfileType,
-  Tournament,
   UserProfile,
 } from "./types";
 import { ActionResolverObject } from "./updater";

--- a/front/src/state/game/types.ts
+++ b/front/src/state/game/types.ts
@@ -1,4 +1,12 @@
-import { TransactionInfo, TransactionType } from "../../common/types";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { TransactionInfo } from "../../common/types";
 import { NoticeInfo } from "./updater";
 
 export enum ActionType {

--- a/front/src/state/game/updater.ts
+++ b/front/src/state/game/updater.ts
@@ -1,8 +1,16 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { useWeb3React } from "@web3-react/core";
 import { default as axios } from "axios";
 import fetch from "cross-fetch";
 import { ethers } from "ethers";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
 import { createClient, defaultExchanges } from "urql/core";
 import { delay } from "wonka";
@@ -10,7 +18,6 @@ import { delay } from "wonka";
 import {
   Input,
   Notice,
-  NoticeDocument,
   NoticesByEpochAndInputDocument,
   NoticesByEpochDocument,
   NoticesDocument,
@@ -19,14 +26,12 @@ import { DEFAULT_GRAPHQL_POLL_TIME, DEFAULT_GRAPHQL_URL } from "../../utils";
 import { setAction } from "../actions/reducer";
 import { useAppSelector } from "../hooks";
 import { Notification, NotificationType } from "../notifications/notifications";
-import { addNotification, setNotifications } from "../notifications/reducer";
-import { useAllTransactions } from "../transactions/hooks";
+import { addNotification } from "../notifications/reducer";
 import { Action, ActionList, ActionStates, ActionType } from "./types";
 axios.defaults.headers.post["Content-Type"] =
   "application/x-www-form-urlencoded";
 import { SERVER_URL } from "./gameSlice";
 import {
-  useGame,
   useUserActiveGameIds,
   useUserBotGameIds,
   useUserBotIds,

--- a/front/src/state/global/actions.ts
+++ b/front/src/state/global/actions.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { createAction } from "@reduxjs/toolkit";
 
 // fired before app renders

--- a/front/src/state/hooks.ts
+++ b/front/src/state/hooks.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 
 import { AppDispatch, AppState } from ".";

--- a/front/src/state/index.ts
+++ b/front/src/state/index.ts
@@ -1,15 +1,17 @@
-import {
-  applyMiddleware,
-  configureStore,
-  getDefaultMiddleware,
-  Middleware,
-} from "@reduxjs/toolkit";
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import { configureStore } from "@reduxjs/toolkit";
 import { load, save } from "redux-localstorage-simple";
 
 import actions from "./actions/reducer";
 import authSlice from "./auth/authSlice";
 import gameSlice from "./game/gameSlice";
-import { ActionList } from "./game/types";
 import notifications from "./notifications/reducer";
 import transactions from "./transactions/reducer";
 

--- a/front/src/state/notifications/hooks.ts
+++ b/front/src/state/notifications/hooks.ts
@@ -1,7 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { NOTIFICATION_TOAST_DURATION_MILLIS } from "../../utils/constants";
 import { useAppSelector } from "../hooks";
 import { Notification } from "./notifications";
-import { NotificationState } from "./reducer";
 
 //useNotifications hook is used to get total list of notifications from the store
 export function useNotifications(): Notification[] {

--- a/front/src/state/notifications/notifications.ts
+++ b/front/src/state/notifications/notifications.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 //Notifications are
 
 export enum NotificationType {

--- a/front/src/state/notifications/reducer.ts
+++ b/front/src/state/notifications/reducer.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { createSlice } from "@reduxjs/toolkit";
 
 import { Notification } from "./notifications";

--- a/front/src/state/transactions/block.ts
+++ b/front/src/state/transactions/block.ts
@@ -1,1 +1,9 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 export {};

--- a/front/src/state/transactions/hooks.ts
+++ b/front/src/state/transactions/hooks.ts
@@ -1,7 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { TransactionResponse } from "@ethersproject/providers";
 import { useWeb3React } from "@web3-react/core";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useCallback, useEffect, useState } from "react";
 import { delay } from "wonka";
 
 import { TransactionInfo } from "../../common/types";

--- a/front/src/state/transactions/reducer.ts
+++ b/front/src/state/transactions/reducer.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { createSlice } from "@reduxjs/toolkit";
 
 import { updateVersion } from "../global/actions";

--- a/front/src/state/transactions/types.ts
+++ b/front/src/state/transactions/types.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { TransactionInfo } from "../../common/types";
 
 export interface TransactionReceipt {

--- a/front/src/state/transactions/updater.ts
+++ b/front/src/state/transactions/updater.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { useWeb3React } from "@web3-react/core";
 import ms from "ms";
 import { useCallback, useEffect, useMemo } from "react";

--- a/front/src/utils/constants.ts
+++ b/front/src/utils/constants.ts
@@ -1,1 +1,9 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 export const NOTIFICATION_TOAST_DURATION_MILLIS = 5000;

--- a/front/src/utils/index.ts
+++ b/front/src/utils/index.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { getAddress } from "@ethersproject/address";
 import { AddressZero } from "@ethersproject/constants";
 import { Contract } from "@ethersproject/contracts";

--- a/front/src/utils/lists/index.ts
+++ b/front/src/utils/lists/index.ts
@@ -1,5 +1,14 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 import { Token } from "../../hooks/token";
 import { parseENSAddress, uriToHttp } from "..";
+
 export const UNI_LIST = "https://tokens.uniswap.org";
 export const UNI_EXTENDED_LIST =
   "https://gateway.pinata.cloud/ipfs/QmaQvV3pWKKaWJcHvSBuvQMrpckV3KKtGJ6p3HZjakwFtX";

--- a/front/src/utils/retry.ts
+++ b/front/src/utils/retry.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/app
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/server/account.py
+++ b/server/account.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
 
 import requests

--- a/server/actions.py
+++ b/server/actions.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import json
 
 

--- a/server/bets.py
+++ b/server/bets.py
@@ -1,5 +1,16 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
-import traceback
 
 import deps
 import notification

--- a/server/bot.py
+++ b/server/bot.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
 import random
 import string

--- a/server/challenge.py
+++ b/server/challenge.py
@@ -1,7 +1,18 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
 import random
 import string
-import time
 
 import deps
 import notification

--- a/server/deps.py
+++ b/server/deps.py
@@ -1,6 +1,15 @@
-import random
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
 
-import chess.engine
 import chess.pgn
 
 from account import AccountBalanceManager

--- a/server/elo.py
+++ b/server/elo.py
@@ -1,3 +1,16 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
 class Elo:
     def __init__(self, k):
         self.ratingDict = {}

--- a/server/game.py
+++ b/server/game.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
 import traceback
 

--- a/server/koh.py
+++ b/server/koh.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
 from dataclasses import dataclass
 

--- a/server/main.py
+++ b/server/main.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 # Copyright 2022 Cartesi Pte. Ltd.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -12,9 +24,7 @@
 
 import json
 import logging
-import string
 import subprocess
-import sys
 import traceback
 from os import environ
 

--- a/server/marketplace.py
+++ b/server/marketplace.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
 import random
 import string

--- a/server/match.py
+++ b/server/match.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import deps
 from participant import Participant
 from times import get_timestamp

--- a/server/matchmaker.py
+++ b/server/matchmaker.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import random
 import string
 

--- a/server/notification.py
+++ b/server/notification.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import json
 import logging
 import random

--- a/server/participant.py
+++ b/server/participant.py
@@ -1,3 +1,16 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
 class Participant:
     def __init__(self, participant=None):
         self.participant = participant

--- a/server/times.py
+++ b/server/times.py
@@ -1,3 +1,15 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 timestamp = 0
 
 

--- a/server/tournament.py
+++ b/server/tournament.py
@@ -1,8 +1,19 @@
+# Copyright 2022-2023 Ultrachess team
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
 import logging
 import random
 import string
 from collections import namedtuple
-from enum import Enum
 
 from match import Match
 from participant import Participant


### PR DESCRIPTION
## Description

As title says, this PR updates copyright headers and removes unused imports in a single commit.

## How has this been tested?

See CI results.

Unfortunately, `yarn build` still fails.

Run-time tested in the browser, but creating a bot still fails with the FileNotFound error.
